### PR TITLE
add link for url fields

### DIFF
--- a/steve/templates/edit.html
+++ b/steve/templates/edit.html
@@ -80,6 +80,9 @@
         {% elif field.type == 'TextArrayField' %}
           <div><textarea name="{{ field.name }}" cols=60 rows=4>{{ field.value|join('\n') }}</textarea></div>
           <div class="helptext">List of items, one per line</div>
+        {% elif field.type == 'URLField' %}
+          <div><input type="text" name="{{ field.name }}" value="{{ field.value }}"></div>
+          <div class="helptext"><a href="{{ field.value }}" target="_blank">{{ field.value }}</a></div>
         {% else %}
           <div>{{ field.value }}</div>
         {% endif %}

--- a/steve/video_reqs.json
+++ b/steve/video_reqs.json
@@ -89,7 +89,7 @@
     "md": false, 
     "choices": [], 
     "null": true, 
-    "type": "CharField", 
+    "type": "URLField",
     "empty_strings": true
   }, 
   {
@@ -116,7 +116,7 @@
     "md": false, 
     "choices": [], 
     "null": true, 
-    "type": "CharField", 
+    "type": "URLField",
     "empty_strings": true
   }, 
   {
@@ -143,7 +143,7 @@
     "md": false, 
     "choices": [], 
     "null": true, 
-    "type": "CharField", 
+    "type": "URLField",
     "empty_strings": true
   }, 
   {
@@ -170,7 +170,7 @@
     "md": false, 
     "choices": [], 
     "null": true, 
-    "type": "CharField", 
+    "type": "URLField",
     "empty_strings": true
   }, 
   {
@@ -197,7 +197,7 @@
     "md": false, 
     "choices": [], 
     "null": true, 
-    "type": "CharField", 
+    "type": "URLField",
     "empty_strings": true
   }, 
   {
@@ -215,7 +215,7 @@
     "md": false, 
     "choices": [], 
     "null": true, 
-    "type": "CharField", 
+    "type": "URLField",
     "empty_strings": true
   }, 
   {


### PR DESCRIPTION
It is useful to have links for fields that have urls because invariably
I will want to check a link when editing metadata. This change

* adds a new URLField type
* adds help text that is a url that opens the target in a new window