### PR TITLE
add get_video_id()

### DIFF
--- a/steve/util.py
+++ b/steve/util.py
@@ -534,3 +534,18 @@ def html_to_markdown(text):
 
     """
     return html2text.html2text(text).strip()
+
+
+def get_video_id(url):
+
+    """Returns the db ID from a full richard site URL
+
+    Example:
+
+    >>> get_video_id("http://pyvideo.org/video/2822/make-api-calls-wicked-fast-with-redis")
+    '2822'
+
+    """
+    v_id = url.split('/video/')[1].split('/')[0]
+    return v_id
+


### PR DESCRIPTION
When updating a existing video, I have the URL, but I need to pass the video_id:

 steve.richardapi.update_video(api_url, auth_token, video_id, video_data)
http://steve.readthedocs.org/en/latest/richardapi.html#steve.richardapi.update_video

So I need a little code to give me that ID.

ps, I have been using this code for years,  started to do some refactoring things into libs, and decided steve.util is where it belongs. 

pps it is dependant on the url pattern.  I am sure with a bunch of work we could make it so changing the pattern won't break the function.. but pfff. I dont think it is worth the work.
