### PR TITLE
Support for running tox to run steve's tests + test on commandline invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *~
 docs/_build
 steve.egg-info
+.tox

--- a/steve/tests/test_steve_cmd.py
+++ b/steve/tests/test_steve_cmd.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+
+from __future__ import print_function
+
+import os
+import subprocess
+
+import pytest
+
+class TestSteveCmd:
+    def test_create_project(self, tmpdir, monkeypatch):
+        # this changes to the temporary pytest directory and back after
+        # the test has been run
+        monkeypatch.chdir(tmpdir)
+        proj = 'testprj'
+        res = subprocess.check_output(['steve-cmd', 'createproject', proj])
+        # you should be able to find the project from the last run with
+        # find /tmp/pytest-current/
+        # note the final "/" as this is a link to
+        #   /tmp/pytest-NNN/test_create_project0
+        assert os.path.exists(os.path.join(proj, 'steve.ini'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = pep8,py27
+
+[testenv]
+commands = py.test steve/tests
+deps =
+    pytest
+    flake8
+
+[testenv:pep8]
+commands =
+   flake8 {posargs}
+
+[flake8]
+show-source = True
+exclude = .hg,.git..tox,dist,.cache,__pycache__,ruamel.zip2tar.egg-info,docs
+


### PR DESCRIPTION
- initial tox.ini file with pep8 and py27 target
- basic test for invocation of steve-cmd to create project
- tox -e pep8: fails on minor cmdline stuff -> not fixed
- tox -e py27: succeeds running all old tests and creation of project
- added .tox (created by running tox) to .gitignore

Additional comments:
- `tox -e py34` indicates that steve is py27 only, that is not clear from the docs
- I did not address the pep8/flake8 issues, most of which were cmdline related, which is changing
- IMO the directory "./steve/tests" should be moved to "./test" (preferably dropping the  the 's', 
  for consistency with Unix/Linux practice. A directory   is a container, implicating multiple objects, 
  hence "src" and not "srcs" and "include" and not "includes")
- running these changes on PR33 shows that it breaks the basic commandline usage

