### PR TITLE
make tox work again

### DIFF
--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -2,7 +2,6 @@ import os
 from unittest import TestCase
 
 from click.testing import CliRunner
-import pytest
 
 from steve.cmdline import cli
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 envlist = pep8,py27
 
 [testenv]
-commands = py.test steve/tests
+commands = py.test tests
 deps =
     pytest
     flake8


### PR DESCRIPTION
steve/tests was moved to tests, but change not updated in  tox.ini
import of pytest currently not necessary -> pep8 failed