### PR TITLE
Prevent webedit from dropping URLs inserting CR

### DIFF
--- a/steve/webedit.py
+++ b/steve/webedit.py
@@ -165,7 +165,7 @@ class WebEditRequestHandler(BaseHTTPRequestHandler):
                     # TODO: Verify the data format
                     value = form_data[key].value
                 elif req['type'] in ('CharField', 'TextField'):
-                    value = form_data[key].value
+                    value = form_data[key].value.replace('\r\n', '\n')
                 elif req['type'] == 'SlugField':
                     # TODO: Verify the data format. Maybe if there is
                     # no slug field, we create it from the title?
@@ -176,6 +176,10 @@ class WebEditRequestHandler(BaseHTTPRequestHandler):
                     value = form_data[key].value
                     value = [mem.strip() for mem in value.split('\n')
                              if mem.strip()]
+                elif req['type'] in ('URLField'):
+                    value = form_data[key].value
+                else:
+                    raise NotImplementedError
 
                 data[key] = value
             else:


### PR DESCRIPTION
webedit:route_save() failed to handle URLField, thereby dropping all
URLs when saving. This was not detected as unrecognised req types did
not throw an error.

A roundtrip edit would change all newlines to carriage-return + newline
in TextField type reqs. This obfuscates real changes in these fields.
This is an artifact of browsers handling textareas.

It could be that richard cannot handle the newlines only, but that is
unlikely for a Unix based tool.