### PR TITLE
Remove hardcoded assumption of "json/0123_" names

### DIFF
--- a/steve/cmdline.py
+++ b/steve/cmdline.py
@@ -128,8 +128,7 @@ def fetch(cfg, ctx, quiet, force):
     if not quiet:
         click.echo(VERSION)
 
-    projectpath = cfg.get('project', 'projectpath')
-    jsonpath = os.path.join(projectpath, 'json')
+    jsonpath = cfg.get('project', 'jsonpath')
 
     # source_url -> filename
     source_map = dict(
@@ -169,7 +168,7 @@ def fetch(cfg, ctx, quiet, force):
         click.echo(u'Created {0}... ({1})'.format(
             stringify(video['title']), filename))
 
-        with open(os.path.join('json', filename), 'w') as fp:
+        with open(os.path.join(jsonpath, filename), 'w') as fp:
             fp.write(convert_to_json(video))
 
         # TODO: what if there's a file there already? on the first one,
@@ -267,18 +266,18 @@ def scrapevideo(ctx, quiet, save, video_url):
     if save:
         cfg = get_project_config()
 
-        projectpath = cfg.get('project', 'projectpath')
-        jsonpath = os.path.join(projectpath, 'json')
+        jsonpath = cfg.get('project', 'jsonpath')
 
         if not os.path.exists(jsonpath):
             os.makedirs(jsonpath)
 
-        fn = 'json/' + generate_filename(data['title']) + '.json'
+        fn = generate_filename(data['title']) + '.json'
+        full_path = os.path.join(jsonpath, fn)
 
         if os.path.exists(fn):
             raise click.ClickException(u'File "%s" already exists!' % fn)
 
-        with open(fn, 'w') as fp:
+        with open(full_path, 'w') as fp:
             fp.write(convert_to_json(data))
         click.echo(u'Saved as {0}'.format(fn))
 

--- a/steve/templates/edit.html
+++ b/steve/templates/edit.html
@@ -7,7 +7,7 @@
 
       <li>
         {% if prev_fn %}
-          <a href="/edit/{{ prev_fn[5:] }}">&lt;&lt;&lt; PREV</a>
+          <a href="/edit/{{ prev_fn }}">&lt;&lt;&lt; PREV</a>
         {% else %}
           &lt;&lt;&lt; PREV
         {% endif %}
@@ -15,7 +15,7 @@
 
       <li>
         {% if next_fn %}
-          <a href="/edit/{{ next_fn[5:] }}">NEXT &gt;&gt;&gt;</a>
+          <a href="/edit/{{ next_fn }}">NEXT &gt;&gt;&gt;</a>
         {% else %}
           NEXT &gt;&gt;&gt;
         {% endif %}
@@ -38,11 +38,11 @@
   to verify the data, run <code>steve verify</code> from the command
   line.
 </p>
-<form id="videoform" action="/save/{{ fn[5:] }}" method="POST">
+<form id="videoform" action="/save/{{ fn }}" method="POST">
 <table>
   <tr>
     <th>filename</th>
-    <td>{{ fn[5:] }}</td>
+    <td>{{ fn }}</td>
   </tr>
 
   {% for field in fields %}

--- a/steve/templates/home.html
+++ b/steve/templates/home.html
@@ -4,11 +4,11 @@
 <table>
   {% for fn, data in data_files %}
     <tr>
-      <td>{{ fn[5:] }}</td>
+      <td>{{ fn }}</td>
       <td>{{ data.title }}</td>
       <td>{{ data.whiteboard }}</td>
       <td>
-        <a href="/edit/{{ fn[5:] }}">edit</a>
+        <a href="/edit/{{ fn }}">edit</a>
       </td>
     </tr>
   {% endfor %}

--- a/steve/webedit.py
+++ b/steve/webedit.py
@@ -34,7 +34,7 @@ PORT = 8000
 
 def get_data(cfg, fn):
     data_files = load_json_files(cfg)
-    data_files = [d for d in data_files if d[0][5:] == fn]
+    data_files = [d for d in data_files if d[0] == fn]
     return data_files[0] if data_files else None
 
 
@@ -193,7 +193,7 @@ class WebEditRequestHandler(BaseHTTPRequestHandler):
 
         save_json_file(cfg, fn, data)
 
-        return self.redirect('/edit/{0}'.format(fn[5:]))
+        return self.redirect('/edit/{0}'.format(fn))
 
 
 def serve():


### PR DESCRIPTION
The util:load_json_files() routine returned a file name as the first
element of the tuples. This name always started with "json/" and
in several places it was assumed:

- that the current directory was the parent directory of "json" (the
  project directory) and that files could be opened by their name
- that the first 5 characters needed stripping when webediting

An extra config entry 'project/jsonpath' is loaded (or created based on
'project/projectpath), and loading/saving is done under this directory.
This means that the json directory could be anywhere as long as
the project configuration correctly specifies where it is.

File names are now passed without any prefix and don't need chomping,
but do always need prefixing by jsonpath when loading/saving.