### PR TITLE
Use YAML as default config file format

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -87,46 +87,52 @@ Example use
 
    In that directory is:
 
-   1. a ``steve.ini`` project config file
-   2. a ``json/`` directory which hold the video metadata json files
-
+   1. a ``steve.yaml`` project config file
+   
+   Later on a ``json/`` and a ``yaml/`` directory which hold the video
+   metadata JSON/YAML files are created.
 
    I usually have all my helper scripts in the project directory since
    it has the ``steve.ini`` file.
 
 3. ``cd europython2011``
 
-4. Edit ``steve.ini``::
+4. Edit ``steve.yaml``::
 
-       [project] 
-
-       # The name of this group of videos. For example, if this was a
-       # conference called EuroPython 2011, then you'd put:
-       # category = EuroPython 2011
-       category = EuroPython 2011
-
-       # The url for where all the videos are listed.
-       # e.g. url = http://www.youtube.com/user/PythonItalia/videos
-       url = http://www.youtube.com/user/PythonItalia/videos
-
-       # If the url is a YouTube-based url, you can either have 'object'
-       # based embed code or 'iframe' based embed code. Specify that
-       # here.
-       youtube_embed = object
-
-       # The url for the richard instance api.
-       # e.g. url = http://example.com/api/v1/
-       # api_url =
-
-       # Your username and api key.
-       #
-       # Alternatively, you can pass this on the command line or put it in a
-       # separate API_KEY file which you can keep out of version control.
-       # e.g. username = willkg
-       #      api_key = OU812
-       # username =
-       # api_key =
-
+    project:
+      # The name of this group of videos. For example, if this was a conference
+      # called EuroPython 2011, then you'd put:
+      # category: EuroPython 2011
+      category: 
+    
+      # The url for where all the videos are listed.
+      # e.g. url: http://www.youtube.com/user/PythonItalia/videos
+      url: 
+    
+      # The projectpath is where steve assumes subdirs if not explitly set
+      # projectpath: /data1/src/pyvideo.steve/tmp
+      # The jsonpath, if set, is where steve will look for the JSON files
+      # jsonpath: /data1/src/pyvideo.steve/tmp/json
+      # The yamlpath, if set, is where steve will look for the YAML files
+      # yamlpath: /data1/src/pyvideo.steve/tmp/yaml
+    
+      # name of status file in project directory (should not be steve.yaml)
+      # status: status.yaml
+    
+      # The url for the richard instance api.
+      # e.g. url: http://example.com/api/v1/
+      api_url:
+    
+      # Your username and api key.
+      # e.g. username: willkg
+      #      api_key: OU812
+      # username:
+      # api_key:
+      #
+      # Alternatively, you can pass this on the command line or put it in a
+      # separate API_KEY file which you can keep out of version control.
+      # cred_file:
+    
 
    If you're not pushing the JSON files to a richard instance, you can
    ignore the ``api_url``, ``username`` and ``api_key`` keys.
@@ -135,25 +141,33 @@ Example use
 
    This fetches the video metadata from that YouTube user and
    generates a series of JSON files---one for each video---and puts
-   them in the ``json/`` directory.
+   them in the ``json/`` directory the command creates if necessary.
 
    The format for each file matches the format expected by the richard
    API.
 
-6. See the status of your video metadata.
+6. Run: ``steve-cmd sync``
+
+   This creates the ``yaml/`` directory and creates YAML metadata
+   files for all JSON files. It also creates/update ``status.yaml`` to
+   hold a time-stamp of the last sync action.
+
+7. See the status of your video metadata.
 
    Run: ``steve-cmd status``
 
    Lists filenames for all videos that have a non-empty whiteboard
    field. Because you've just downloaded the metadata, all of the
    videos have a whiteboard field stating they haven't been edited,
-   yet.
+   yet. 
+   *This currently works on the JSON files, ``sync`` beforehand if necessary.*
 
    Run: ``steve-cmd ls``
 
    Lists titles and some other data for each video in the set.
+   *This currently works on the JSON files, ``sync`` beforehand if necessary.*
 
-7. Now you go through and edit the json metadata. There are a few ways
+8. Now you go through and edit the json or yaml metadata. There are a few ways
    to do this. **Don't** just pick one way---mix and match them to
    reduce the work required.
 
@@ -234,11 +248,38 @@ Example use
       This is helpful when you have a few things to fix and don't feel
       like writing json.
 
+   4. **Edit the combined YAML files**
+
+      the command::
+
+          steve-cmd yaml
+ 
+      will create a temporary YAML file with all of the combined YAML
+      file information. It then starts your editor ($EDITOR). After
+      quiting the editor those files which were edited are used to
+      overwrite the individual YAML files (based on filename and hash
+      information included in initial comments).
+    
+   5. **Combine and split YAML files**
+
+      You can use other tools than your default editor on the temporary
+      combined YAML file by specifying::
+
+          EDITOR=/path/to/command steve-cmd yaml
+
+      You can also combine the YAML files into a file you specify::
+
+          steve-cmd yaml --name some_name.yaml --combine
+
+      run your command on that and then split them into the individual
+      files::
+
+          steve-cmd yaml --name some_name.yaml --split
 
    If there are other tools you want to use---go for it. Anything
    to get the job done.
 
-8. Run: ``steve-cmd verify``
+9. Run: ``steve-cmd verify``
 
    This goes through all the json files and verifies correctness.
 
@@ -248,7 +289,9 @@ Example use
 
    Are values that should be in HTML in HTML?
 
-9. Now it's time to submit your changes!
+   *This currently works on the JSON files, ``sync`` beforehand if necessary.*
+
+10. Now it's time to submit your changes!
 
    If you do not have an API key that gives you write access to the server,
    then tar the ``json/`` directory up and send it to someone who does.
@@ -260,7 +303,8 @@ Example use
 
    That will create the videos on the server and update the JSON
    files with the new ids.
-
+   Be sure to run ``steve-cmd sync`` before pushing if you edit the
+   metadata in the YAML files.
 
 That's it!
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ User/Contributor Guide
    license
    installation
    commandline
+   sync
    library
    restapi
    richardapi

--- a/docs/sync.rst
+++ b/docs/sync.rst
@@ -1,0 +1,116 @@
+===========================
+Syncing JSON and YAML files
+===========================
+
+The ``steve-cmd`` utility supports YAML files in addition to JSON
+files for metadata. To support a gradual transition and adaptation of
+tools to the YAML format it relies on synchronisation of the JSON and
+YAML metadata to work on either of the two sets.
+
+In the future more commands will directly work on the YAML metadata,
+eventually only relying on doing a sync to JSON before uploading to
+richard (and maybe even not that). 
+
+Syncing is currently not automated (i.e. ``steve-cmd verify`` verifies
+the JSON files, and you have to run ``steve-cmd sync`` **manually** to
+incorporate changes to your YAML files to get those verified). This will probably change
+in the future.
+
+Usage
+=====
+
+Syncing is done by issuing::
+
+   steve-cmd sync
+
+This creates any directories necessary and compares the last
+modification time for the JSON and YAML files, relying on them to have
+the same basename (without extension). These times are compared to the
+last sync timestamp stored in ``status.yaml`` (which is updated on a
+successful sync). If both the JSON and the YAML (assuming both are
+available) metadata files of **any** of the videos been touched, the
+sync will fail and no metadata is synced (see `resolving sync
+problems`_). 
+
+It is perfectly fine to edit ``json/001.json`` and
+``yaml/007.yaml`` and then synchronise. Just don't touch
+``json/001.json`` and ``yaml/001.yaml``.
+
+Any missing files are created both from ``json/`` to ``yaml/`` and
+vice versa.
+
+Sync often, if nothing needs syncing nothing is changed except for the
+last synced timestamp.
+
+Differences between JSON and YAML files
+---------------------------------------
+
+During the sync to, and from, YAML the following are auto-adapted to
+provide a more readable YAML file:
+
+- dates (``YYYY-MM-DD``) are converted to datetime objects before saving
+  resulting in::
+
+      recorded: 2015-08-08
+  instead of quoted string: ``recorded: "2015-08-08"``
+- Empty strings are converted to ``None`` and written as nothing
+  ::
+
+     language:
+     
+  instead of the empty string (``language: ""``), so you can directly 
+  type something there, without having to insert
+  that between double quotes, or remove those (unless the string has
+  special characters you don't need those quotes in YAML
+- Multi-line strings are converted to literal block scalars (with some
+  ``ruamel.yaml`` magic)::
+
+      summary: |-
+        Moritz Gronbach - What's the fuzz all about? Randomized data 
+        generation for robust unit testing
+        [EuroPython 2015]
+      
+   which is more readable than the single line JSON, or non block
+   YAML, version. Take care with indentation when editing these
+   scalars. This is essentially two-space indented markdown.
+
+As indicated above, this "magic" is undone, syncing from YAML to JSON.
+
+
+Resolving sync problems
+=======================
+
+If one or more metadata files have been edited both on the json and
+the yaml side, you have to resolve this by hand before
+proceeding. Running ``steve-cmd sync`` will fail and give you the list
+of files that are a problem.
+
+If you know both files are the same (touched but not edited) remove
+one of the files.
+
+If only one is up-to-date remove the other file, ``steve-cmd sync``
+will recreate it from the newer one
+
+If both side actually have useful changes, you can copy them from 
+file A to file B and remove file A. Since A and B are JSON and YAML
+this might not be too easy, the alternative is (assuming ``json/001.json``
+and ``yaml/001.yaml`` were both edited)::
+
+  mv -i json/001.json json/999.json
+  steve-cmd sync
+  
+(pick a number different from 999 if the file already exists, do the
+above ``mv`` for all the files having problems, before calling ``steve-cmd sync``). 
+
+Now use your favourite ``diff`` tool, e.g. ``meld``, to update ``yaml/001.yaml``::
+
+  meld yaml/001.yaml yaml/999.yaml
+
+and if yaml/001.yaml is up to date::
+  
+  rm yaml/999.yaml json/999.yaml json/001.yaml
+  steve-cmd sync
+
+**If you change the timestamp in the status file, any files that were
+edited on both sides and have modification times older than the
+timestamp, will be considered "in-sync"**

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'pytest',
         'tabulate',
         'youtube-dl',
+        'ruamel.yaml',
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'tabulate',
         'youtube-dl',
         'ruamel.yaml',
+        'ruamel.yaml.convert',
     ],
     entry_points="""
         [console_scripts]

--- a/steve/cmdline.py
+++ b/steve/cmdline.py
@@ -6,7 +6,6 @@
 # license.
 #######################################################################
 
-import ConfigParser
 import os
 import sys
 import traceback
@@ -26,6 +25,7 @@ from steve.util import (
     get_project_config,
     get_project_config_file_name,
     load_json_files,
+    NoOptionError,
     save_json_file,
     save_json_files,
     scrape_video,
@@ -119,7 +119,7 @@ def fetch(cfg, ctx, quiet, force):
 
     try:
         url = cfg.get('project', 'url')
-    except ConfigParser.NoOptionError:
+    except NoOptionError:
         url = ''
 
     if not url:
@@ -287,7 +287,7 @@ def push(cfg, ctx, quiet, apikey, update, overwrite, files):
     if not apikey:
         try:
             apikey = cfg.get('project', 'api_key')
-        except ConfigParser.NoOptionError:
+        except NoOptionError:
             pass
     if not apikey:
         raise click.ClickException(
@@ -330,7 +330,7 @@ def push(cfg, ctx, quiet, apikey, update, overwrite, files):
             )
         else:
             click.echo('Category {0} exists on site.'.format(category))
-    except ConfigParser.NoOptionError:
+    except NoOptionError:
         category = None
 
     errors = []
@@ -446,7 +446,7 @@ def pull(cfg, ctx, quiet, apikey):
     if not apikey:
         try:
             apikey = cfg.get('project', 'api_key')
-        except ConfigParser.NoOptionError:
+        except NoOptionError:
             pass
     if not apikey:
         raise click.ClickException(

--- a/steve/cmdline.py
+++ b/steve/cmdline.py
@@ -35,6 +35,7 @@ from steve.util import (
     with_config,
 )
 from steve.webedit import serve
+from steve.yamldata import YAML_Data
 
 
 BYLINE = ('steve-cmd: {0} ({1}).'.format(steve.__version__,
@@ -498,6 +499,41 @@ def pull(cfg, ctx, quiet, apikey):
 
     click.echo('Saving files....')
     save_json_files(cfg, data)
+
+
+@cli.command()
+@click.pass_context
+@with_config
+def sync(cfg, ctx):
+    """Sync YAML/JSON data."""
+    yd = YAML_Data(cfg)
+    yd.sync()
+
+
+@cli.command()
+@click.argument('name', required=False)
+@click.option('--split/--no-split', default=False)
+@click.option('--combine/--no-combine', default=False)
+@click.pass_context
+@with_config
+def yaml(cfg, ctx, name, split, combine):
+    """Sync YAML/JSON data."""
+    if split and combine:
+        print('Specify only one of --split and --combine')
+        return
+    if (split or combine) and not name:
+        print('Specify a name with --name NAME, when splitting or combining')
+        return
+    yd = YAML_Data(cfg)
+    combine_name = None
+    if name:
+        combine_name = os.path.join(cfg.get('project', 'projectpath'), name)
+    if split:
+        yd.split(combine_name)
+    elif combine:
+        yd.combine(combine_name)
+    else:
+        yd.edit(combine_name)
 
 
 def exception_handler(exc_type, exc_value, exc_tb):

--- a/steve/util.py
+++ b/steve/util.py
@@ -67,6 +67,7 @@ class Config(object):
     def __init__(self):
         self._file_name = None
         self._project_path = None
+        self._status = None
 
     @property
     def project_path(self):
@@ -109,14 +110,17 @@ class Config(object):
     @property
     def status(self):
         """retrieve status information"""
-        sfn = self.status_file_name
-        if os.path.exists(sfn):
-            return yaml_load(open(sfn))
-        return yaml_load(textwrap.dedent("""\
-        # status file for yaml
-        yaml:
-        last_sync: 2000-01-01 00:00:00
-        """))
+        if self._status is None:
+            sfn = self.status_file_name
+            if os.path.exists(sfn):
+                self._status = yaml_load(open(sfn))
+            else:
+                self._status = yaml_load(textwrap.dedent("""\
+                # status file for yaml
+                yaml:
+                  last_sync: 2000-01-01 00:00:00
+                """))
+        return self._status
 
     @property
     def status_file_name(self):
@@ -125,6 +129,12 @@ class Config(object):
         except NoOptionError:
             res = self.default_status
         return os.path.join(self.project_path, res)
+
+    def save_status(self):
+        with open(self.status_file_name, 'w') as fp:
+            yaml.dump(self.status, fp,
+                      Dumper=yaml.RoundTripDumper,
+                      allow_unicode=True)
 
     def _load(self):
         """Manipulate loaded config file to provide extra/missing information."""

--- a/steve/yamldata.py
+++ b/steve/yamldata.py
@@ -1,0 +1,97 @@
+#######################################################################
+# This file is part of steve.
+#
+# Copyright (C) 2015
+# Licensed under the Simplified BSD License. See LICENSE for full
+# license.
+#######################################################################
+
+from __future__ import print_function
+
+import os
+import datetime
+import tempfile
+
+from ruamel.yaml.convert import SyncJSON, datetime_to_time
+
+
+class YAML_Data(SyncJSON):
+    def __init__(self, cfg):
+        self._cfg = cfg
+
+    def sync(self):
+        print('calling sync')
+        json_path = self._cfg.get('project', 'jsonpath')
+        if not os.path.exists(json_path):
+            os.makedirs(json_path)
+        yaml_path = self._cfg.get('project', 'yamlpath')
+        if not os.path.exists(yaml_path):
+            os.makedirs(yaml_path)
+        ts = self._cfg.status['yaml']['last_sync']
+        last_synced = datetime_to_time(ts)
+        super(YAML_Data, self).sync(json_path, yaml_path, last_synced=last_synced)
+        self._cfg.status['yaml']['last_sync'] = datetime.datetime.now()
+        self._cfg.save_status()
+        # self.equal_all(json_path, yaml_path)
+
+    def edit(self, combine_name=None):
+        if combine_name is None:
+            combine_name = tempfile.mktemp(suffix='.yaml')
+            print(combine_name)
+            _tmp_file = True
+        else:
+            _tmp_file = False
+        yaml_path = self._cfg.get('project', 'yamlpath')
+        assert os.path.isdir(yaml_path)
+        super(YAML_Data, self).combine(combine_name, yaml_path)
+        os.system('{0} {1}'.format(os.environ['EDITOR'], combine_name))
+        if not os.path.exists(yaml_path):
+            os.makedirs(yaml_path)
+        super(YAML_Data, self).split(combine_name, yaml_path)
+        if _tmp_file:
+            os.remove(combine_name)
+
+    def split(self, combine_name):
+        yaml_path = self._cfg.get('project', 'yamlpath')
+        assert os.path.isdir(yaml_path)
+        super(YAML_Data, self).split(combine_name, yaml_path)
+
+    def combine(self, combine_name):
+        yaml_path = self._cfg.get('project', 'yamlpath')
+        assert os.path.isdir(yaml_path)
+        super(YAML_Data, self).combine(combine_name, yaml_path)
+
+    def json_yaml_adapt(self, data):
+        """adapt inviddual elements of the data"""
+        data = super(YAML_Data, self).json_yaml_adapt(data)
+        if isinstance(data, dict):
+            for k in data:
+                v = data[k]
+                if isinstance(v, basestring):
+                    if len(v) == 0:
+                        data[k] = None
+                    if len(v) == 10 and v[4] == '-' and v[7] == '-':
+                        # date string of for 2015-10-05
+                        try:
+                            d = datetime.date(*map(int, v.split('-')))
+                        except:
+                            continue
+                        data[k] = d
+        return data
+
+    def yaml_json(self, yfn, jfn):
+        print('converting', os.path.basename(yfn))
+        super(YAML_Data, self).yaml_json(yfn, jfn)
+
+    def json_yaml(self, jfn, yfn):
+        print('converting', os.path.basename(jfn))
+        super(YAML_Data, self).json_yaml(jfn, yfn)
+
+    def yaml_json_adapt(self, data):
+        data = super(YAML_Data, self).yaml_json_adapt(data)
+        if isinstance(data, dict):
+            for k in data:
+                v = data[k]
+                if v is None:
+                    data[k] = ''
+        return data

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from click.testing import CliRunner
 
 from steve.cmdline import cli
-
+from steve.util import SteveConfig
 
 # helpful for testing command line stuff
 #
@@ -34,7 +34,7 @@ class CreateprojectTestCase(TestCase):
 
             result = runner.invoke(cli, ('createproject', 'testprj'))
             assert result.exit_code == 0
-            assert os.path.exists(os.path.join(path, 'testprj', 'steve.ini'))
+            assert os.path.exists(os.path.join(path, 'testprj', SteveConfig.file_name))
 
     def test_directory_already_exists(self):
         runner = CliRunner()


### PR DESCRIPTION
Further abstraction from ConfigParser, introduction of YAML as
(default) config file format.

- introduces NoOptionError, and have IniConfig.get() throw that and
  remove further cmdline.py and util.py dependency on ConfigParser
- steve.yaml/YamlConfig is now the default name/type for config file
- old projects (steve.ini) are still found and will be read
- parametrized test for config file creation/retrieval (on util.py level)
  for both config types